### PR TITLE
Type hint and style compatibility

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,15 @@
+name: Black
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: "./"
+          jupyter: true
+          version: "~= 22.1"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint with flake8
+name: Lint with ruff, check with mypy
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
     branches:
       - "main"
   schedule:
-    # Nightly tests run on master by default:
+    # Weekly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.
     #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
     - cron: "0 0 * * SUN"
@@ -31,13 +31,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest flake8
+          pip install ruff mypy tqdm types-tqdm pandas pandas-stubs types-openpyxl
       - name: Install package
         run: |
-          pip install .[test]
-      - name: Lint with flake8
+          pip install .
+      - name: Lint with ruff
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # ruff check using toml settings. Ignore unused argument errors.
+          ruff check .
+      - name: Type check with mypy
+        run: |
+          # mypy check. Ignore uncheckable modules.
+          mypy . --ignore-missing-imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,75 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+select = [
+    "E",
+    "F",
+    "ARG",
+    "B",
+    "D",
+    "PLC",
+    "NPY",
+    "RUF",
+    "ANN",
+    "C",
+    "T",
+    "EXE",
+    "ISC",
+    "ICN",
+    "PIE",
+    "SLF",
+    "TCH",
+    "PTH",
+    "ERA",
+    "NPY",
+]
+ignore = ["ANN101","ANN102","ANN002","ANN003","ANN401","D213","D203","D406","T201"]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+per-file-ignores = {}
+
+# Same as Black.
+line-length = 88
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+target-version = "py39"
+
+[tool.mypy]
+show_error_codes = true
+warn_unused_ignores = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+python_files = "*.py"
+testpaths = [ "src" ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [metadata]
 name = aggforce
 version = 0.0.1
@@ -17,7 +21,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.9
 install_requires =
     numpy
     qpsolvers

--- a/src/aggforce/agg.py
+++ b/src/aggforce/agg.py
@@ -247,4 +247,4 @@ def force_smoothness(array):
     is often used as a metric of quality for force-maps.
     """
 
-    return np.mean(array**2)
+    return np.mean(array ** 2)

--- a/src/aggforce/featlinearmap.py
+++ b/src/aggforce/featlinearmap.py
@@ -1,42 +1,268 @@
-r"""Provides data-based routines for finding the optimal force aggregation map
-that is linear with respect to fixed molecular features.
-"""
+r"""Routines for for featurized non-linear force map optimization.
 
+NOTE: Maps of this type are more complex than simple configurationally-independent force
+maps and have shown any benefit. For typical force mapping, stick to linear maps.
+
+Types and routines for general feature calculation are included.
+
+Configurationally dependent (non-linear) force maps may be made by using a featurization
+function which characterizes each configuration. The force map may then be made linear
+to this featurization. The linear coefficients do not change as a function of
+configuration, but the output of the featurizers do.
+
+This module provides routines for optimizing this kind of force map. Other modules
+provide additional featurization functions.
+"""
+from typing import (
+    Any,
+    Union,
+    Tuple,
+    List,
+    Callable,
+    Final,
+    ClassVar,
+    Generator,
+    Iterable,
+    Generic,
+    TypeVar,
+    overload,
+    Literal,
+)
+from typing_extensions import TypedDict
+from queue import SimpleQueue, Empty
 from copy import deepcopy
 import numpy as np
-from numpy.random import choice
-import scipy.sparse as ss
-from qpsolvers import solve_qp
-from .map import CLAMap
-from .linearmap import reduce_constraint_sets
-from queue import SimpleQueue, Empty
+from numpy.random import default_rng
+import scipy.sparse as ss  # type: ignore [import-untyped]
+from qpsolvers import solve_qp  # type: ignore [import-untyped]
+from .map import LinearMap, CLAMap
+from .linearmap import reduce_constraint_sets, SolverOptions, DEFAULT_SOLVER_OPTIONS
+from .constfinder import Constraints
+
+# This defines featurizers and their output via types.
+
+# featurizers output a dictionary with these keys.
+FEATS_KEY: Final = "feats"
+DIVS_KEY: Final = "divs"
+NAMES_KEY: Final = "names"
+# we also have to spell these literals out below because of mypy limits.
+Features = TypedDict(
+    "Features",
+    {
+        "feats": Iterable[np.ndarray],
+        "divs": Iterable[np.ndarray],
+        "names": Union[Iterable[str], None],
+    },
+)
+
+# here we characterize the featurizers themselves. GeneralizedFeaturizes include
+# complex lists of generators which act like Features. GeneralizedFeaturizers output
+# those or features.
+Featurizer = Callable[[np.ndarray, LinearMap, Constraints], Features]
+GeneralizedFeatures = Union[Features, "FeatZipper"]
+# first option here actually does need a union in its output because of mypy
+GeneralizedFeaturizer = Union[
+    Callable[[np.ndarray, LinearMap, Constraints], Union[Features, "FeatZipper"]],
+    Featurizer,
+]
+
+T = TypeVar("T")
+CallableT = TypeVar("CallableT", bound=Callable)
+
+
+class FeatZipper:
+    r"""Lazily combines the output of multiple featurizers.
+
+    NOTE: This function does not combine _featurizers_; it combines their
+    output. To combine featurizers use multifeaturize.
+
+    Featurizers output a dict with keys for features ("feats"), divergences
+    ("divs"), and names ("names"). This class combines the _output_ of multiple
+    featurizers, providing dictionary-like interface for accessing features and
+    divergences aggregated across all the results. This class can be used with
+    lazy featurizers (those providing generators) and is itself lazy: "feats" and
+    "divs" index generators.
+
+    In other words, instances of this class are objects which can be indexed
+    using the same keys as featurizer output. Indexing returns generators that
+    iterate over the data aggregated from the featurized content provided at
+    initialization.
+
+    The information for the produced feature and divergence generators comes
+    from shared data present in each instance. The original data are iterated
+    over as needed (in the case of lazy features, this implies that memory and
+    computation is performed only when needed by the aggregate output) and
+    served through the provided generators.
+    """
+
+    # these keys provide understanding into the feature dictionary format
+    generator_keys = frozenset([FEATS_KEY, DIVS_KEY])
+    name_key = "names"
+
+    # joiners has the particular functions for combining arrays from each
+    # content member's iteration. They are indexed by the appropriate key.
+    # e.g., "feats"'s callable combines iterations from "feats" entries.
+
+    # members cannot be static methods and in this dictionary, so they are
+    # lambdas.
+    joiners: ClassVar = {
+        FEATS_KEY: lambda args: np.concatenate(args, axis=2),
+        DIVS_KEY: lambda args: np.concatenate(args, axis=1),
+    }
+
+    def __init__(self, content: List[GeneralizedFeatures]) -> None:
+        r"""Initialize a FeatZipper from list of content dictionaries.
+
+        Arguments:
+        ---------
+        content (list of dictionaries):
+            List of the dictionaries that  we want to aggregate and iterate
+            over. Each dictionary should be the output of a featurizer; that is,
+            it should have "feats", "divs", and "names" as keys.  "feats" and
+            "divs" should index an iterable of numpy arrays and "names" should
+            be a list of strings.
+        """
+        self.reset(content)
+        # no current support for names
+        self.names = None
+
+    def keys(self) -> frozenset:
+        r"""Return a frozenset of all viable keys for indexing.
+
+        Returns:
+        -------
+        Frozenset of all feasible keys.
+        """
+        return self.generator_keys.union(frozenset([NAMES_KEY]))
+
+    def reset(self, content: Iterable[GeneralizedFeatures]) -> None:
+        r"""Prepare internal state.
+
+        Internal state includes setting up iterators and queues. The queues are
+        used to temporarily aggregate the output of content's iterators when
+        necessary. The queues are used to aggregate results as we (indirectly)
+        iterate over the input iterables in content.
+
+        Arguments:
+        ---------
+        content (list of dicts):
+            list of dictionaries, each of which is the output of a
+            featurization function.  See __init__'s content argument for more
+            details.
+        """
+        self.source = {}
+        for key in self.generator_keys:
+            # mypy cannot check to see if we are obeying the named dictionary
+            self.source.update({key: zip(*[o[key] for o in content])})  # type: ignore
+        queues: List[SimpleQueue] = [SimpleQueue() for _ in self.generator_keys]
+        self._queues = dict(zip(self.generator_keys, queues))
+
+    def _makegenerator(self, key: str) -> Generator[Any, None, None]:
+        r"""Create generator for a specified key.
+
+        These generators query the internal queues for results from the input
+        dictionaries. If the queues are empty, they try to repopulate them; if
+        that fails, they return.
+
+        Arguments:
+        ---------
+        key (str):
+            The key used to extract the series from the content dictionaries for
+            aggregation.
+
+        Yields:
+        ------
+        Aggregated numpy.ndarrays formed from results under key in content dictionaries.
+
+        Examples:
+        --------
+        If "feats" is passed, we return a generator; at each iteration
+        this generator grabs an iteration from the iterator under "feats" from
+        each content dictionary, combines them into a single array, and returns them.
+        """
+        while True:
+            try:
+                item = self._queues[key].get(block=False)
+            except Empty:
+                try:
+                    self._populate(key=key, exception=False)
+                    item = self._queues[key].get(block=False)
+                except Empty:
+                    return
+            yield item
+
+    def __getitem__(self, key: str) -> Union[Generator[Any, None, None], None]:
+        r"""Return generator associated with key or (in the case of names) None.
+
+        Arguments:
+        ---------
+        key (str):
+            A member of self.generator_keys or NAME_KEY. If
+            NAME_KEY, then self.names is returned. If a member of
+            generator_keys, a generator which iterates over the aggregated
+            form of that key's content in self.content. See the class
+            description for more details.
+
+        Returns:
+        -------
+        Generator or self.names
+        """
+        if key in self.generator_keys:
+            return self._makegenerator(key)
+        if key == NAMES_KEY:
+            return self.names
+        raise KeyError("Invalid key; valid keys are {}".format(self.keys()))
+
+    def _populate(self, key: Union[str, None] = None, exception: bool = True) -> None:
+        r"""Add item to queues by continuing source generators one step.
+
+        The internal queues' purposes are to store the output of the input
+        feature data for processing. This method is called when other methods
+        realize the queues are empty.
+
+        Arguments:
+        ---------
+        key (str or None):
+            Specifies which queue to refill. Should be one of the keys in
+            self.generator_keys. If None, all queues refilled.
+        exception (boolean):
+            If true, StopIteration exceptions are not caught; as a result, if
+            the internal iterators are depleted StopIteration will be thrown. If
+            false, this situation is caught and the method simply leaves the
+            queues untouched and returns.
+        """
+        if key is None:
+            keys = self.generator_keys
+        else:
+            keys = frozenset([key])
+        for key in keys:
+            try:
+                data = next(self.source[key])
+                agg = self.joiners[key](data)
+                self._queues[key].put(agg)
+            except StopIteration as e:
+                if exception:
+                    raise e
+        return
 
 
 def qp_feat_linear_map(
-    forces,
-    xyz,
-    config_mapping,
-    featurizer,
-    kbt,
-    n_constraint_frames=20,
-    constraints=set(),
-    sparse=True,
-    solver_args=dict(
-        solver="osqp",
-        eps_abs=1e-7,
-        max_iter=int(1e3),
-        polish=True,
-        polish_refine_iter=10,
-    ),
-    l2_regularization=1e1,
-):
-    r"""Searches for the force map which produces the average lowest mean
-    square norm of the mapped force. The produced map is linear with respect
-    to user-provided features.
+    forces: np.ndarray,
+    xyz: np.ndarray,
+    config_mapping: LinearMap,
+    featurizer: Featurizer,
+    kbt: float,
+    n_constraint_frames: int = 20,
+    constraints: Union[None, Constraints] = None,
+    sparse: bool = True,
+    solver_args: SolverOptions = DEFAULT_SOLVER_OPTIONS,
+    l2_regularization: float = 1e1,
+) -> CLAMap:
+    r"""Search for force map with lowest mean square norm of the mapped force.
 
-    Note: Uses a quadratic programming solver with equality constraints.
+    The produced map is linear with respect to user-provided features.
 
-    Arguments
+    Arguments:
     ---------
     forces (numpy.ndarray):
         Three dimensional array of shape (n_frames,n_sites,n_dims). Contains the
@@ -88,9 +314,13 @@ def qp_feat_linear_map(
         resulting mapping. Doing so here is more complex as the mapping changes
         as a function of frame.
 
-    NOTE: The featurization function output must conform to the following
-    format. The entry for the 'feat' and 'div' keys is a list, and each
-    element in each list corresponds to the features that are used for a
+    Notes:
+    -----
+    Uses a quadratic programming solver with equality constraints.
+
+    Additionally, the featurization function output must conform to the
+    following format. The entry for the 'feat' and 'div' keys is a list, and
+    each element in each list corresponds to the features that are used for a
     particular coarse-grained site; e.g., the first entry in both the feat and
     div entries correspond to coarse-grained site index 0.
 
@@ -106,13 +336,15 @@ def qp_feat_linear_map(
 
     See the documentation for exp2_feat for more information.
 
-    Returns
+    Returns:
     -------
     CLAMap object characterizing force mapping.
     """
+    if constraints is None:
+        constraints = set()
 
     feat_results = featurizer(xyz, config_mapping, constraints)
-    feats, divs, names = [feat_results[key] for key in ["feats", "divs", "names"]]
+    feats, divs, names = [feat_results[key] for key in [FEATS_KEY, DIVS_KEY, NAMES_KEY]]  # type: ignore
 
     per_site_feat_coef = []
     for ind, (feat, div) in enumerate(zip(feats, divs)):
@@ -157,21 +389,29 @@ def qp_feat_linear_map(
         coefs=per_site_feat_coef,
         mapping=config_mapping,
         constraints=constraints,
-        tags=dict(feat_names=names, coef_list=per_site_feat_coef),
+        tags={"feat_names": names, "coef_list": per_site_feat_coef},
     )
 
     return force_mapping
 
 
-def _constr_arrays(features, cg_ind, config_mapping, n_frames, sparse=True):
-    """Produces a constraint 2-array (A) and target 1-array (b) for
-    later Ax=b constrained quadratic optimization.
+def _constr_arrays(
+    features: np.ndarray,
+    cg_ind: int,
+    config_mapping: LinearMap,
+    n_frames: int,
+    sparse: bool = True,
+) -> Tuple[Union[np.ndarray, ss.csc_matrix], np.ndarray]:
+    """Produce a constraint array and target array for constrained optimization.
+
+    Produce a constraint array (A) and target 1-array (b) for later Ax=b
+    constrained quadratic optimization.
 
     The returned 2-array is of shape (n_cg_sites*n_frames,n_features) and the
     1-array is of shape (n_cg_sites*n_frames,). Is sparse is true, the first
     array is a sparse csc matrix.
 
-    Arguments
+    Arguments:
     ---------
     features (numpy.ndarray):
         Array characterizing the features for a single coarse-grained site.
@@ -193,7 +433,7 @@ def _constr_arrays(features, cg_ind, config_mapping, n_frames, sparse=True):
         algebraic operations on this output may change as it is a matrix and not
         and array.
 
-    Returns
+    Returns:
     -------
     Ordered pair: first element is a (n_cg_sites*n_frames,n_features) sized 2-array
     (or scipy.sparse.csc_matrix, see below), second element is 1-dimensional array
@@ -202,9 +442,8 @@ def _constr_arrays(features, cg_ind, config_mapping, n_frames, sparse=True):
     If sparse, a sparse csc_matrix is returned for the first array. Note that
     the algebraic operations change as it is a matrix and not and array.
     """
-
     # get random subset of calculated features
-    frame_indices = choice(len(features), size=n_frames, replace=False)
+    frame_indices = default_rng().choice(len(features), size=n_frames, replace=False)
     subsetted_features = features[frame_indices]
 
     mult_array = np.einsum(
@@ -221,11 +460,19 @@ def _constr_arrays(features, cg_ind, config_mapping, n_frames, sparse=True):
     return (mult, target)
 
 
-def _feat_linear_mapping(featurizer, coefs, mapping, constraints, **kwargs):
-    """Creates a CLAMap instance for a map that is constructed from a
-    fixed parameterization and linear coefficients.
+def _feat_linear_mapping(
+    featurizer: Featurizer,
+    coefs: List[np.ndarray],
+    mapping: LinearMap,
+    constraints: Constraints,
+    **kwargs
+) -> CLAMap:
+    """Create CLAMap for a linearly parameterized map.
 
-    Arguments
+    Creates a CLAMap instance for a map that is constructed from a fixed
+    parameterization and linear coefficients.
+
+    Arguments:
     ---------
     featurizer (callable):
         A callable for featurizing the system which uses the following as input:
@@ -255,18 +502,20 @@ def _feat_linear_mapping(featurizer, coefs, mapping, constraints, **kwargs):
     constraints (set of frozensets):
         Each entry is a frozenset of coarse-grained indices, the group of which
         is constrained. Passed to featurizer.
+    **kwargs:
+        Passed to CLAMap initialization.
 
-    Returns
+    Returns:
     -------
     CLAMap instance.
     """
 
-    def scale_f(copoints):
+    def scale_f(copoints: np.ndarray) -> np.ndarray:
         feats = featurizer(copoints, mapping, constraints)["feats"]
         weights = [np.einsum("...ij,j->...i", f, c) for f, c in zip(feats, coefs)]
         return np.stack(weights, axis=1)
 
-    def trans_f(copoints):
+    def trans_f(copoints: np.ndarray) -> np.ndarray:
         divs = featurizer(copoints, mapping, constraints)["divs"]
         weights = [np.einsum("tij,i->tj", f, c) for f, c in zip(divs, coefs)]
         return np.stack(weights, axis=1)
@@ -282,12 +531,39 @@ def _feat_linear_mapping(featurizer, coefs, mapping, constraints, **kwargs):
     return force_mapping
 
 
-def id_feat(points, cmap, constraints, return_ids=False):
-    """Vector valued feature which associates a one-hotted label to each
+@overload
+def id_feat(
+    points: np.ndarray,
+    cmap: LinearMap,
+    constraints: Constraints,
+    return_ids: Literal[False],
+) -> GeneralizedFeatures:
+    ...
+
+
+@overload
+def id_feat(
+    points: np.ndarray,
+    cmap: LinearMap,
+    constraints: Constraints,
+    return_ids: Literal[True],
+) -> np.ndarray:
+    ...
+
+
+def id_feat(
+    points: np.ndarray,
+    cmap: LinearMap,
+    constraints: Constraints,
+    return_ids: bool = False,
+) -> Union[np.ndarray, GeneralizedFeatures]:
+    """Feature a one-hotted label to each fine-grained site.
+
+    Vector valued feature which associates a one-hotted label to each
     fine-grained site.  Labels are unique, except that they are shared between
     constraint groups.
 
-    Arguments
+    Arguments:
     ---------
     points (numpy.ndarray):
         Points characterizing the positions of fine-grained sites as a function
@@ -305,7 +581,7 @@ def id_feat(points, cmap, constraints, return_ids=False):
         d/group of each fine-grained site. Useful for creating other features
         which respect constraints, but not a feature in itself.
 
-    Returns
+    Returns:
     -------
     If return_ids is True, return a numpy.ndarray with the shape (n_fg_sites,).
     Else: A dict with the following key-value pairs:
@@ -320,7 +596,6 @@ def id_feat(points, cmap, constraints, return_ids=False):
     generators), the entries for each cg_site are views to the same numpy array,
     so the memory footprint is only that of a single cg_site.
     """
-
     # get list of groups of fine-grained sites which have to share id features
     # because of constraints
     groups = deepcopy(constraints)
@@ -335,7 +610,8 @@ def id_feat(points, cmap, constraints, return_ids=False):
         return ids
     else:
         for label, fg_set in enumerate(reduced_groups):
-            _ = [places.append([fg_ind, label]) for fg_ind in fg_set]
+            for fg_ind in fg_set:
+                places.append([fg_ind, label])
 
     n_frames = points.shape[0]
     n_fg_sites = cmap.n_fg_sites
@@ -349,15 +625,13 @@ def id_feat(points, cmap, constraints, return_ids=False):
 
     divs = np.zeros((n_frames, n_types, n_dim), dtype=np.float32)
 
-    return dict(feats=[feats] * n_cg_sites, divs=[divs] * n_cg_sites, names=None,)
+    return {"feats": [feats] * n_cg_sites, "divs": [divs] * n_cg_sites, "names": None}
 
 
-def multifeaturize(featurizers):
-    """Combines multiple featurization functions into a single featurization function.
+def multifeaturize(featurizers: List[GeneralizedFeaturizer]) -> GeneralizedFeaturizer:
+    """Combine multiple featurization functions into a single featurization function.
 
-    NOTE: Output names are not supported and are set to None.
-
-    Arguments
+    Arguments:
     ---------
     featurizers (list of callables):
         A list, each member of which must use the following as callable input:
@@ -373,7 +647,7 @@ def multifeaturize(featurizers):
             'divs': list of divergence mats (n_frames, n_feats, n_dim)
             'names': None or list of name strings (n_feat)
 
-    Returns
+    Returns:
     -------
     Callable which returns the output expected of a featurization function: a
     dictionary with the following key value pairs:
@@ -383,18 +657,26 @@ def multifeaturize(featurizers):
     This output is created by combining the pertinent arrays along the n_feat
     dimensions.  Input is the same as it was for each individual featurization
     function.
+
+    Note:
+    ----
+    Output names are not supported and are set to None.
     """
 
-    def composite(*args, **kwargs):
-        output = [feat(*args, **kwargs) for feat in featurizers]
+    def composite(
+        copoints: np.ndarray, config_mapping: LinearMap, constraints: Constraints
+    ) -> GeneralizedFeatures:
+        output = [feat(copoints, config_mapping, constraints) for feat in featurizers]
         return FeatZipper(content=output)
 
     return composite
 
 
 class Multifeaturize:
-    """Combines multiple featurizers into a single featurizer by creating a
-    callable object. Combination is done lazily where possible.
+    """Lazily combine featurizers into a single featurizer.
+
+    Combine multiple featurizers into a single featurizer by creating a
+    derivative callable object. Combination is done lazily where possible.
 
     Usage:
         m = Multifeaturize([feat1,feat2])
@@ -408,24 +690,25 @@ class Multifeaturize:
     This is an object and not a closure to allow for self description.
     """
 
-    def __init__(self, featurizers):
-        """Initializes Multifeaturize object from a list of featurizers.
+    def __init__(self, featurizers: Iterable[GeneralizedFeaturizer]) -> None:
+        """Initialize Multifeaturize object from a list of featurizers.
 
-        Arguments
+        Arguments:
         ---------
         featurizers (list of callables):
             List of featurization callables. See qp_feat_linear_map for more
-            information.
+            information. Featurizers have the following type signature:
 
-        Returns
+
+        Returns:
         -------
         Callable which evaluates and aggregates the output from each element of
         featurizers.
         """
-
         self.featurizers = featurizers
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """Generate string representation."""
         sp = "    "
         msg = []
         msg.append("{} instance:".format(self.__class__))
@@ -435,7 +718,8 @@ class Multifeaturize:
             msg.extend(func_msg)
         return "\n".join(msg)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """Generate brief string representation."""
         msg = []
         msg.append("{}():".format(self.__class__))
         for ind, func in enumerate(self.featurizers):
@@ -444,209 +728,32 @@ class Multifeaturize:
             msg.append(func_msg)
         return " ".join(msg)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> GeneralizedFeatures:
         """Evaluate each featurizer and return the wrapped output.
 
-        Arguments
+        Arguments:
         ---------
-        args/kwargs:
+        *args:
+            Passed to each featurizer.
+        **kwargs:
             Passed to each featurizer.
 
-        Returns
+        Returns:
         -------
         FeatZipper object wrapping the output of all featurizers.
         """
-
         results = [f(*args, **kwargs) for f in self.featurizers]
         return FeatZipper(content=results)
 
 
-class FeatZipper:
-    r"""Lazily combines the output of multiple featurizers.
-
-    NOTE: This function does not combine _featurizers_; it combines their
-    output. To combine featurizers see multifeaturize.
-
-    Featurizers output a dict with keys for features ("feats"), divergences
-    ("divs"), and names ("names"). This class combines the _output_ of multiple
-    featurizers, providing dictionary-like interface for accessing features and
-    divergences aggregated across all the results. This class can be used with
-    lazy featurizers (those providing generators) and is itself lazy: "feats" and
-    "divs" index generators.
-
-    In other words, instances of this class are objects which can be indexed
-    using the same keys as featurizer output. Indexing returns generators that
-    iterate over the data aggregated from the featurized content provided at
-    initialization.
-
-    The information for the produced feature and divergence generators comes
-    from shared data present in each instance. The original data are iterated
-    over as needed (in the case of lazy features, this implies that memory and
-    computation is performed only when needed by the aggregate output) and
-    served through the provided generators.
-    """
-
-    # these keys provide understanding into the feature dictionary format
-    feat_key = "feats"
-    div_key = "divs"
-    generator_keys = set([feat_key, div_key])
-    name_key = "names"
-
-    # joiners has the particular functions for combining arrays from each
-    # content member's iteration. They are indexed by the appropriate key.
-    # e.g., "feats"'s callable combines iterations from "feats" entries.
-
-    # members cannot be static methods and in this dictionary, so they are
-    # lambdas.
-    joiners = {
-        feat_key: lambda args: np.concatenate(args, axis=2),
-        div_key: lambda args: np.concatenate(args, axis=1),
-    }
-
-    def __init__(self, content):
-        r"""Initialize a FeatZipper from list of content dictionaries.
-
-        Arguments
-        ---------
-        content (list of dictionaries):
-            List of the dictionaries that  we want to aggregate and iterate
-            over. Each dictionary should be the output of a featurizer; that is,
-            it should have "feats", "divs", and "names" as keys.  "feats" and
-            "divs" should index an iterable of numpy arrays and "names" should
-            be a list of strings.
-        """
-
-        self.reset(content)
-        # no current support for names
-        self.names = None
-
-    def keys(self):
-        r"""Returns a set of all viable keys for indexing.
-
-        Returns
-        -------
-        Set of all feasible keys.
-        """
-
-        return self.generator_keys.union(set([self.name_key]))
-
-    def reset(self, content):
-        r"""Prepares internal state.
-
-        Internal state includes setting up iterators and queues. The queues are
-        used to temporarily aggregate the output of content's iterators when
-        necessary. The queues are used to aggregate results as we (indirectly)
-        iterate over the input iterables in content.
-
-        Arguments
-        ---------
-        content (list of dicts):
-            list of dictionaries, each of which is the output of a
-            featurization function.  See __init__'s content argument for more
-            details.
-        """
-
-        self.source = dict()
-        for key in self.generator_keys:
-            self.source.update({key: zip(*[o[key] for o in content])})
-        queues = [SimpleQueue() for _ in self.generator_keys]
-        self._queues = dict(zip(self.generator_keys, queues))
-
-    def _makegenerator(self, key):
-        r"""Creates a generator for a specified key.
-
-        These generators query the internal queues for results from the input
-        dictionaries. If the queues are empty, they try to repopulate them; if
-        that fails, they return.
-
-        Arguments
-        ---------
-        key (hashable):
-            The key used to extract the series from the content dictionaries for
-            aggregation.
-
-        Yields
-        ------
-        Aggregated numpy.ndarrays formed from results under key in content dictionaries.
-
-        EXAMPLE: if "feats" is passed, we return a generator; at each iteration
-        this generator grabs an iteration from the iterator under "feats" from
-        each content dictionary, combines them into a single array, and returns them.
-        """
-
-        while True:
-            try:
-                item = self._queues[key].get(block=False)
-            except Empty:
-                try:
-                    self._populate(key=key, exception=False)
-                    item = self._queues[key].get(block=False)
-                except Empty:
-                    return
-            yield item
-
-    def __getitem__(self, key):
-        r"""Implements indexing. Returns generator associated with key or (in
-        the case of names) None.
-
-        Arguments
-        ---------
-        key (hashable):
-            A member of self.generator_keys or \{self.name_key\}. If
-            name_key, then self.names is returned. If a member of
-            generator_keys, a generator which iterates over the aggregated
-            form of that key's content in self.content. See the class
-            description for more details.
-
-        Returns
-        -------
-        Generator or self.names
-        """
-
-        if key in self.generator_keys:
-            return self._makegenerator(key)
-        if key == self.name_key:
-            return self.names
-        raise KeyError("Invalid key; valid keys are {}".format(self.keys()))
-
-    def _populate(self, key=None, exception=True):
-        r"""Adds an item to internal queues by continuing source generators one
-        step.
-
-        The internal queues' purposes are to store the output of the input
-        feature data for processing. This method is called when other methods
-        realize the queues are empty.
-
-        Arguments
-        ---------
-        key (hashable or None):
-            Specifies which queue to refill. Should be one of the keys in
-            self.generator_keys. If None, all queues refilled.
-        exception (boolean):
-            If true, StopIteration exceptions are not caught; as a result, if
-            the internal iterators are depleted StopIteration will be thrown. If
-            false, this situation is caught and the method simply leaves the
-            queues untouched and returns.
-        """
-
-        if key is None:
-            keys = self.generator_keys
-        else:
-            keys = [key]
-        for key in keys:
-            try:
-                data = next(self.source[key])
-                agg = self.joiners[key](data)
-                self._queues[key].put(agg)
-            except StopIteration as e:
-                if exception:
-                    raise e
-        return
+# mypy limitations in the current version block paramspec usage
+R = TypeVar("R")
 
 
-class Curry:
-    """Uses a callable class to curry a function using named and keyword
-    arguments.
+class Curry(Generic[R]):
+    """Callable class to curry a function.
+
+    Uses named and keyword arguments.
 
     That is: for f(x,y), curry(f,y=a) returns a callable g, where g(b) =
     f(x=b,y=a). Non-keyword arguments also work--- they are passed after any
@@ -654,29 +761,33 @@ class Curry:
     function with certain options set.
 
     This is an object and not a closure to allow for self description.
+
+    Type hints only maintain return value.
     """
 
-    def __init__(self, func, *args, **kwargs):
+    def __init__(self, func: Callable[..., R], *args, **kwargs) -> None:
         """Initialize a Curry object from a function and arguments.
 
-        Arguments
+        Arguments:
         ---------
         func (callable):
             Function to be curried.
-        args/kwargs:
+        *args:
+            Used to curry func.
+        **kwargs:
             Used to curry func.
 
-        Returns
+        Returns:
         -------
         Callable which evaluates func appending args and kwargs to any passed
         arguments.
         """
-
         self.args = args
         self.kwargs = kwargs
         self.func = func
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """Generate string representation."""
         sp = "    "
         func_msg = [sp + o for o in str(self.func).split("\n")]
         args_msg = [sp + o for o in str(self.args).split("\n")]
@@ -691,7 +802,8 @@ class Curry:
         msg.extend(kwargs_msg)
         return "\n".join(msg)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """Generate brief string representation."""
         func_msg = repr(self.func)
         args_msg = repr(self.args)
         kwargs_msg = repr(self.kwargs)
@@ -707,49 +819,55 @@ class Curry:
             msg.append(kwargs_msg)
         return " ".join(msg)
 
-    def __call__(self, *sub_args, **sub_kwargs):
+    def __call__(self, *sub_args, **sub_kwargs) -> R:
+        """Call curried function."""
         return self.func(*sub_args, *self.args, **sub_kwargs, **self.kwargs)
 
 
-def curry(func, *args, **kwargs):
-    """Curries a function using named and keyword arguments.
+# this should be replaced by the call from functools
+# type hinting may be improvable, but not clear because of old mypy.
+def curry(func: Callable[..., T], *args, **kwargs) -> Callable[..., T]:
+    """Curry a function using named and keyword arguments.
 
-    That is: for f(x,y), curry(f,y=a) returns a function g, where g(b) =
-    f(x=b,y=a). Non-keyword arguments also work--- they are passed after any
-    non-keyword arguments passed to g.  Useful when creating a featurization
-    function with certain options set.
+    For f(x,y), curry(f,y=a) returns a function g, where g(b) = f(x=b,y=a).
+    Non-keyword arguments also work--- they are passed after any non-keyword
+    arguments passed to g.  Useful when creating a featurization function with
+    certain options set.
 
-    Arguments
+    Type hints only maintain return type.
+
+    Arguments:
     ---------
     func (callable):
         Function to be curried.
-    args/kwargs:
+    *args:
+        Used to curry func.
+    **kwargs:
         Used to curry func.
 
-    Returns
+    Returns:
     -------
     Callable which evaluates func appending args and kwargs to any passed
     arguments.
     """
 
-    def curried_f(*sub_args, **sub_kwargs):
+    def curried_f(*sub_args, **sub_kwargs) -> T:
         return func(*sub_args, *args, **sub_kwargs, **kwargs)
 
     return curried_f
 
 
-def flatten(nested_list):
+def flatten(nested_list: Iterable[Iterable[Any]]) -> List[Any]:
     """Flattens a nested list.
 
-    Arguments
+    Arguments:
     ---------
     nested_list (list of lists):
         List of the form [[a,b...],[h,g,...],...]
 
-    Returns
+    Returns:
     -------
     Returns a list where the items are the subitems of nested_list. For example,
     [[1,2],[3,4] would be transformed into [1,2,3,4].
     """
-
     return [item for sublist in nested_list for item in sublist]

--- a/src/aggforce/featlinearmap.py
+++ b/src/aggforce/featlinearmap.py
@@ -349,11 +349,7 @@ def id_feat(points, cmap, constraints, return_ids=False):
 
     divs = np.zeros((n_frames, n_types, n_dim), dtype=np.float32)
 
-    return dict(
-        feats=[feats] * n_cg_sites,
-        divs=[divs] * n_cg_sites,
-        names=None,
-    )
+    return dict(feats=[feats] * n_cg_sites, divs=[divs] * n_cg_sites, names=None,)
 
 
 def multifeaturize(featurizers):

--- a/src/aggforce/jaxfeat.py
+++ b/src/aggforce/jaxfeat.py
@@ -174,11 +174,7 @@ def gb_feat(
     else:
         divs = [divver(x) for x in range(cmap.n_cg_sites)]
 
-    return dict(
-        feats=feats,
-        divs=divs,
-        names=None,
-    )
+    return dict(feats=feats, divs=divs, names=None,)
 
 
 def abatch(func, arr, chunk_size, *args, **kwargs):
@@ -280,7 +276,7 @@ def distances(
     if return_displacements:
         return displacement_matrix
     if square:
-        distance_matrix = (displacement_matrix**2).sum(axis=-1)
+        distance_matrix = (displacement_matrix ** 2).sum(axis=-1)
     else:
         distance_matrix = jnp.linalg.norm(displacement_matrix, axis=-1)
     if return_matrix:
@@ -335,7 +331,7 @@ def gaussian_dist_basis(
     the output shape is (2,2,5).
     """
 
-    pow_grid_points = jnp.linspace(inner**dist_power, outer**dist_power, n_basis)
+    pow_grid_points = jnp.linspace(inner ** dist_power, outer ** dist_power, n_basis)
     grid_points = pow_grid_points ** (1 / dist_power)
     feats = [
         clipped_gauss(inp=dists, center=o, width=width, clip=clip) for o in grid_points

--- a/src/aggforce/jaxmapval.py
+++ b/src/aggforce/jaxmapval.py
@@ -23,9 +23,7 @@ from .jaxfeat import distances, clipped_gauss
 
 
 def random_uniform_forces(
-    positions,
-    scale=1.0,
-    randg=None,
+    positions, scale=1.0, randg=None,
 ):
     r"""Returns the forces of a random linear (ramp) force-field applied to each
     frame in a trajectory.
@@ -57,19 +55,11 @@ def random_uniform_forces(
     shape = positions.shape
     x, y, z = 2 * randg.random(size=3) - 1
     force = np.array([x, y, z])
-    force /= ((force**2).sum()) ** (0.5)
+    force /= ((force ** 2).sum()) ** (0.5)
     force *= scale
     expanded_force = force[None, None, :]
-    parti_tiled_force = np.repeat(
-        expanded_force,
-        repeats=shape[0],
-        axis=0,
-    )
-    tiled_force = np.repeat(
-        parti_tiled_force,
-        repeats=shape[1],
-        axis=1,
-    )
+    parti_tiled_force = np.repeat(expanded_force, repeats=shape[0], axis=0,)
+    tiled_force = np.repeat(parti_tiled_force, repeats=shape[1], axis=1,)
     return tiled_force
 
 
@@ -109,9 +99,9 @@ def rsqpg_forces(positions, inner, outer, width, randg=None, sq_args=True):
     """
 
     if sq_args:
-        outer = outer**2
-        inner = inner**2
-        width = width**2
+        outer = outer ** 2
+        inner = inner ** 2
+        width = width ** 2
     if randg is None:
         randg = r.default_rng()
     interval_width = outer - inner

--- a/src/aggforce/jaxmapval.py
+++ b/src/aggforce/jaxmapval.py
@@ -1,6 +1,7 @@
-r"""Provides methods for validation and summarizing maps. We focus on calculate
-the projection of forces along basis functions and the difference in force
-residuals between pairs of force-fields.
+r"""Methods for validation and summarizing maps.
+
+We focus on calculate the projection of forces along basis functions and the difference
+in force residuals between pairs of force-fields.
 
 This module requires JAX.
 
@@ -15,25 +16,29 @@ Rudzinski, Joseph F., and W. G. Noid. "Coarse-graining entropy, forces, and
 structures." The Journal of chemical physics 135.21 (2011): 214101.
 """
 
+from typing import TypeVar, Union, Callable, Iterable, overload, Literal, List
 import numpy as np
 import numpy.random as r
 import jax
 from .agg import force_smoothness
 from .jaxfeat import distances, clipped_gauss
 
+ArrayT = TypeVar("ArrayT", bound=Union[jax.Array, np.ndarray])
+
 
 def random_uniform_forces(
-    positions, scale=1.0, randg=None,
-):
-    r"""Returns the forces of a random linear (ramp) force-field applied to each
-    frame in a trajectory.
+    positions: np.ndarray,
+    scale: float = 1.0,
+    randg: Union[r.Generator, None] = None,
+) -> np.ndarray:
+    r"""Obtain forces of a random linear force-field applied to a trajectory.
 
     This function evaluates a linear force-field which assigns a single unique
     3-vector to each site at each frame. That is, all sites in all frames have
     the same force (same direction and magnitude). This force has magnitude
     scale and points in a shared random direction, which is set using randg.
 
-    Arguments
+    Arguments:
     ---------
     positions (array, jnp.DeviceArray or np.ndarray):
         3-d array containing positions as a function of time. Assumed to be of
@@ -44,27 +49,43 @@ def random_uniform_forces(
         random number generator used to define the force direction. To make the
         direction deterministic, supply a Generator instance with a fixed seed.
 
-    Returns
+    Returns:
     -------
     3-dimensional nd.ndaray containing the forces for each frame in positions.
     Has shape (n_frames,n_sites,n_dims).
     """
-
     if randg is None:
         randg = r.default_rng()
     shape = positions.shape
     x, y, z = 2 * randg.random(size=3) - 1
     force = np.array([x, y, z])
-    force /= ((force ** 2).sum()) ** (0.5)
+    force /= ((force**2).sum()) ** (0.5)
     force *= scale
     expanded_force = force[None, None, :]
-    parti_tiled_force = np.repeat(expanded_force, repeats=shape[0], axis=0,)
-    tiled_force = np.repeat(parti_tiled_force, repeats=shape[1], axis=1,)
+    parti_tiled_force = np.repeat(
+        expanded_force,
+        repeats=shape[0],
+        axis=0,
+    )
+    tiled_force = np.repeat(
+        parti_tiled_force,
+        repeats=shape[1],
+        axis=1,
+    )
     return tiled_force
 
 
-def rsqpg_forces(positions, inner, outer, width, randg=None, sq_args=True):
-    r"""Calculates the forces of a random Gaussian force-field for each frame in
+def rsqpg_forces(
+    positions: Union[jax.Array, np.ndarray],
+    inner: float,
+    outer: float,
+    width: float,
+    randg: Union[r.Generator, None] = None,
+    sq_args: bool = True,
+) -> jax.Array:
+    r"""Calculate the forces of a random force-field.
+
+    Estimates the forces of a random Gaussian force-field for each frame in
     a trajectory.
 
     randg is used to generate a random number in between inner and outer; this
@@ -74,7 +95,7 @@ def rsqpg_forces(positions, inner, outer, width, randg=None, sq_args=True):
     with respect to positions (and multiplied by -1) to provide forces for each
     frame.
 
-    Arguments
+    Arguments:
     ---------
     positions (array, jnp.DeviceArray or np.ndarray):
         3-d array containing positions as a function of time. Assumed to be of
@@ -92,16 +113,15 @@ def rsqpg_forces(positions, inner, outer, width, randg=None, sq_args=True):
     sq_args (boolean):
         If truthy, inner, outer, and width are squared before they are used.
 
-    Returns
+    Returns:
     -------
     3-dimensional jnp.DeviceArray containing the forces for each frame in
     positions. Has shape (n_frames,n_sites,n_dims).
     """
-
     if sq_args:
-        outer = outer ** 2
-        inner = inner ** 2
-        width = width ** 2
+        outer = outer**2
+        inner = inner**2
+        width = width**2
     if randg is None:
         randg = r.default_rng()
     interval_width = outer - inner
@@ -109,16 +129,44 @@ def rsqpg_forces(positions, inner, outer, width, randg=None, sq_args=True):
     return sq_gaussian_forces(positions, offset, width)
 
 
+@overload
 def random_residual_shift(
-    coords,
-    forces,
-    n_samples=1000,
-    randg=None,
-    method=rsqpg_forces,
-    average=False,
+    coords: np.ndarray,
+    forces: np.ndarray,
+    n_samples: int,
+    randg: Union[r.Generator, None],
+    method: Callable[..., jax.Array],  # see docstring
+    average: Literal[True],
     **kwargs
-):
-    r"""Calculates the force residual (i.e. force_smoothness) difference between a
+) -> float:
+    ...
+
+
+@overload
+def random_residual_shift(
+    coords: np.ndarray,
+    forces: np.ndarray,
+    n_samples: int,
+    randg: Union[r.Generator, None],
+    method: Callable[..., jax.Array],  # see docstring
+    average: Literal[False],
+    **kwargs
+) -> List[float]:
+    ...
+
+
+def random_residual_shift(
+    coords: np.ndarray,
+    forces: np.ndarray,
+    n_samples: int = 1000,
+    randg: Union[r.Generator, None] = None,
+    method: Callable[..., jax.Array] = rsqpg_forces,  # see docstring
+    average: bool = False,
+    **kwargs
+) -> Union[float, List[float]]:
+    r"""Estimate the force roughness of generated force-fields.
+
+    Calculates the force residual (i.e. force_smoothness) difference between a
     series of randomly generated force-fields and a flat force-field.
 
     This procedure is based on the following property:
@@ -142,7 +190,7 @@ def random_residual_shift(
     from them. The reference is the force residual of a constant-everywhere
     force-field (which as a force of zero everywhere).
 
-    Arguments
+    Arguments:
     ---------
     coords (np.ndarray):
         3-array that has the positions of the system as a function of time.
@@ -166,16 +214,15 @@ def random_residual_shift(
     average (boolean):
         whether to average the shifts or return a list of all of the
         shifts.
-    kwargs:
-        passed to method at each iteration via **.
+    **kwargs:
+        passed to method at each iteration.
 
-    Returns
+    Returns:
     -------
-    if sum is truthy, returns a scalar (often as a JAX 0-array depending out the
+    if average is truthy, returns a scalar (often as a JAX 0-array depending out the
     particular method used); else, a list of such scalars with an entry for each
     randomly generated force-field.
     """
-
     if randg is None:
         randg = r.default_rng()
     vals = []
@@ -189,21 +236,47 @@ def random_residual_shift(
         return [x - fs for x in vals]
 
 
+@overload
 def random_force_proj(
-    coords,
-    forces,
-    n_samples=1000,
-    randg=None,
-    method=rsqpg_forces,
-    average=True,
+    coords: np.ndarray,
+    forces: np.ndarray,
+    n_samples: int,
+    randg: Union[r.Generator, None],
+    method: Callable[..., jax.Array],
+    average: Literal[True],
     **kwargs
-):
-    r"""Performs mscg_ip projections for a randomly generated set of bases.
+) -> float:
+    ...
+
+
+@overload
+def random_force_proj(
+    coords: np.ndarray,
+    forces: np.ndarray,
+    n_samples: int,
+    randg: Union[r.Generator, None],
+    method: Callable[..., jax.Array],
+    average: Literal[False],
+    **kwargs
+) -> Iterable[float]:
+    ...
+
+
+def random_force_proj(
+    coords: np.ndarray,
+    forces: np.ndarray,
+    n_samples: int = 1000,
+    randg: Union[r.Generator, None] = None,
+    method: Callable[..., jax.Array] = rsqpg_forces,
+    average: bool = True,
+    **kwargs
+) -> Union[float, Iterable[float]]:
+    r"""Perform MSCG projections on random basis functions.
 
     Generates n_samples different basis functions and projects forces on them.
     See mscg_ip for more details.
 
-    Arguments
+    Arguments:
     ---------
     coords (np.ndarray):
         3-array that has the positions of the system as a function of time.
@@ -216,7 +289,7 @@ def random_force_proj(
         this is the length of the output.
     randg (None or r.Generator instance):
         random number generator used to define the basis functions. To make the
-        selection of basis functios deterministic, supply a Generator instance
+        selection of basis functions deterministic, supply a Generator instance
         with a fixed seed.
     method (callable):
         Callable used to generate the random basis functions. coords, randg and
@@ -228,12 +301,11 @@ def random_force_proj(
     kwargs:
         passed to method at each iteration via **.
 
-    Returns
+    Returns:
     -------
-    if sum is truthy, returns a scalar (often as a JAX 0-array depending out the
+    if average is truthy, returns a scalar (often as a JAX 0-array depending out the
     particular method used); else, a list of such scalars.
     """
-
     if randg is None:
         randg = r.default_rng()
     vals = []
@@ -246,8 +318,8 @@ def random_force_proj(
         return vals
 
 
-def mscg_ip(forces, funcs):
-    r"""Performs a MSCG-like inner product.
+def mscg_ip(forces: ArrayT, funcs: ArrayT) -> float:
+    r"""Perform a MSCG-like inner product.
 
     This function does an element-wise product of forces and funcs, sums over all
     dims, and then divides by the size of the first (0th) dimension.
@@ -268,7 +340,7 @@ def mscg_ip(forces, funcs):
     function is still defined for general arrays, but does not correspond to the
     same type of sample-based approximation to the content described above.
 
-    Arguments
+    Arguments:
     ---------
     forces (3-array):
         3-array (jax or numpy) containing the forces associated each timestep of
@@ -278,28 +350,28 @@ def mscg_ip(forces, funcs):
         shape (n_steps,n_sites,n_dims).  NOTE: This is _not_ a callable. It is
         an array representing the output of a suitable function.
 
-    Returns
+    Returns:
     -------
     Returns a 0-dim array containing the value of the inner product. The exact
     type depends on the input types.
     """
-
     n_steps = forces.shape[0]
-    return (funcs * forces).sum() / n_steps
+    return float((funcs * forces).sum() / n_steps)
 
 
 # note that JAX peculiarities make a gaussian energy function that is a function
 # of distances and not square distances return forces that are nans.
 @jax.jit
-def sq_gaussian_energies(positions, offset, width):
-    r"""Calculates the per-frame energies of a positions array with a shared
-    Gaussian potential.
+def sq_gaussian_energies(
+    positions: jax.Array, offset: float, width: float
+) -> jax.Array:
+    r"""Calculate per-frame energies of positions with Gaussian potential.
 
     A single Gaussian (with properties set by offset and width) is applied to
     each pairwise distance in each frame. This is then summed over each frame to
     produce the trajectory of energies.
 
-    Arguments
+    Arguments:
     ---------
     positions (jnp.DeviceArray):
         3-array with shape (n_frames, n_sites, n_dims) that contains the
@@ -309,11 +381,10 @@ def sq_gaussian_energies(positions, offset, width):
     width (float):
         sets the Gaussian width through clipped_gauss
 
-    Returns
+    Returns:
     -------
     1-dimensional jnp.DeviceArray containing the energy of each frame.
     """
-
     distance_arr = distances(positions, return_matrix=True, square=True)
     return clipped_gauss(distance_arr, center=offset, width=width, clip=None).sum(
         axis=[1, 2]

--- a/src/aggforce/linearmap.py
+++ b/src/aggforce/linearmap.py
@@ -1,33 +1,48 @@
-r"""Provides routines for finding the optimal linear force aggregation map from a
-given molecular trajectory.
-"""
+r"""Provides routines for the optimal linear force maps."""
 
+from typing import Union, Dict
+from typing_extensions import TypedDict
+from itertools import product
 import copy
 import numpy as np
-from qpsolvers import solve_qp
+from qpsolvers import solve_qp  # type: ignore [import-untyped]
 from .map import LinearMap
+from .constfinder import Constraints
+
+SolverOptions = TypedDict(
+    "SolverOptions",
+    {
+        "solver": str,
+        "eps_abs": float,
+        "max_iter": int,
+        "polish": bool,
+        "polish_refine_iter": int,
+    },
+)
+DEFAULT_SOLVER_OPTIONS: SolverOptions = {
+    "solver": "osqp",
+    "eps_abs": 1e-7,
+    "max_iter": int(1e3),
+    "polish": True,
+    "polish_refine_iter": 10,
+}
 
 
 def qp_linear_map(
-    forces,
-    config_mapping,
-    constraints=None,
-    l2_regularization=0.0,
-    xyz=None,
-    solver_args=dict(
-        solver="osqp",
-        eps_abs=1e-7,
-        max_iter=int(1e3),
-        polish=True,
-        polish_refine_iter=10,
-    ),
-):
-    r"""Searches for the linear force map which produces the average lowest mean
-    square norm of the mapped force.
+    forces: np.ndarray,
+    config_mapping: LinearMap,
+    constraints: Union[None, Constraints] = None,
+    l2_regularization: float = 0.0,
+    xyz: Union[np.ndarray, None] = None,  # noqa: ARG001
+    solver_args: SolverOptions = DEFAULT_SOLVER_OPTIONS,
+) -> LinearMap:
+    r"""Search for optimal linear force map.
+
+    Optimally is determined via  average lowest mean square norm of the mapped force.
 
     Note: Uses a quadratic programming solver with equality constraints.
 
-    Arguments
+    Arguments:
     ---------
     forces (np.ndarray):
         three dimensional array of shape (n_steps,n_sites,n_dims). Contains the
@@ -45,11 +60,12 @@ def qp_linear_map(
     solver_args (dict):
         Passed as options to qp_solve to solve quadratic program.
 
-    Returns
+    Returns:
     -------
     LinearMap object characterizing force mapping.
     """
-
+    if constraints is None:
+        constraints = set()
     # flatten force array
     reshaped_fs = qp_form(forces)
     # construct geom constraint matrix
@@ -75,8 +91,8 @@ def qp_linear_map(
     return LinearMap(np.stack(per_site_maps))
 
 
-def qp_form(target):
-    r"""Transforms a 3 array (target) to a particular form of 2-array.
+def qp_form(target: np.ndarray) -> np.ndarray:
+    r"""Transform 3-array to a particular form of 2-array.
 
     e.g. target is (n_steps,n_sites,n_dims=3)
     output is (n_steps*n_dims,n_sites) where the rows are ordered as
@@ -85,15 +101,16 @@ def qp_form(target):
         step=0, dim=2
         step=1, dim=0
     """
-
     mixed = np.swapaxes(target, 1, 2)
     reshaped = np.reshape(mixed, (mixed.shape[0] * mixed.shape[1], -1))
     return reshaped
 
 
-def make_bond_constraint_matrix(n_sites, constraints):
-    r"""Makes a molecular constraint matrix connective a generalized mapping
-    coefficient to the expanded mapping coefficient.
+def make_bond_constraint_matrix(n_sites: int, constraints: Constraints) -> np.ndarray:
+    r"""Make constraint matrix connecting a generalized maps to the expanded maps.
+
+    This matrix connects a generalized mapping coefficient to the expanded
+    mapping coefficient.
 
     When creating optimal force maps, atoms which are molecularly constrained to
     each other are most easily handled by having them share mapping
@@ -114,7 +131,7 @@ def make_bond_constraint_matrix(n_sites, constraints):
     the vector [a b b c d], i.e., sites 1 and 2 are constrained to have the
     same value.
 
-    Arguments
+    Arguments:
     ---------
     n_sites (integer):
         Total number of sites in the system. In the context of the quadratic
@@ -125,7 +142,7 @@ def make_bond_constraint_matrix(n_sites, constraints):
         constrained relative to each other (and should have identical mapping
         coefficients)
 
-    Returns
+    Returns:
     -------
     2-dim numpy.ndarray
     """
@@ -150,9 +167,11 @@ def make_bond_constraint_matrix(n_sites, constraints):
     return mat
 
 
-def reduce_constraint_sets(constraints):
-    r"""Reduces a set of sets of constrained sites into a set of larger disjoint
-    sets of constrained sites.
+def reduce_constraint_sets(constraints: Constraints) -> Constraints:
+    r"""Reduces constraints to disjoint constraints.
+
+    Reduces a set of frozensets of constrained sites into a set of larger disjoint
+    frozensets of constrained sites.
 
     If a single atom has a constrained bonds to two separate atoms, the list of
     bond constraints does not make it clear that all three of these atoms are
@@ -161,17 +180,18 @@ def reduce_constraint_sets(constraints):
     constraint entry, but does so for all atoms and all sized constrains such
     that the returned list of constraint's members are all disjoint.
 
-    Arguments
+    Arguments:
     ---------
     constraints (set of frozensets of integers):
         Each member set contains indices of atoms which are constrained relative
         to each other
 
-    Returns
+    Returns:
     -------
     set of frozensets of integers.
 
     Example:
+    -------
         {{1,2},{2,3},{4,5}}
         is transformed into
         {{1,2,3},{4,5}}
@@ -184,7 +204,6 @@ def reduce_constraint_sets(constraints):
     seems to be a form of flood search using breadth first search should be
     revised.
     """
-
     constraints_copy = copy.copy(constraints)
     agged_constraints = set()
 
@@ -202,18 +221,18 @@ def reduce_constraint_sets(constraints):
     # begin again. The new set is returned when we run out of elements in
     # constraints copy to process.
 
-    new = set(constraints_copy.pop())
+    new = frozenset(constraints_copy.pop())
     second_try = False
     while True:
         to_add = [x for x in constraints_copy if new.intersection(x)]
         new = new.union(*to_add)
         constraints_copy.difference_update(to_add)
         if not to_add:
-            agged_constraints.add(frozenset(new))
+            agged_constraints.add(new)
             if second_try:
                 second_try = False
                 try:
-                    new = constraints_copy.pop()
+                    new = frozenset(constraints_copy.pop())
                 except KeyError:
                     break
             else:
@@ -221,30 +240,37 @@ def reduce_constraint_sets(constraints):
     return agged_constraints
 
 
-def constraint_lookup_dict(constraints):
-    r"""Transforms a set of frozensets of constraints to a dictionary connecting
+def constraint_lookup_dict(constraints: Constraints) -> Dict[int, int]:
+    r"""Transform constraints to a dictionary connecting each member to a parent.
+
+    Transforms a set of frozensets of constraints to a dictionary connecting
     each set member to a master member.
 
     The smallest member of each member set is designated as the parent member.
     Each remaining element in that set is added to the return dictionary as a
     key which points to its parent member.
 
+    Arguments:
+    ---------
+    constraints:
+        Constraints to collapse
+
     Example:
-        constraints = {{1,2,3},{4,5},{6,7}}
-        is transformed into the following dictionary:
-        {
-            3:1
-            2:1
-            5:4
-            7:6
-        }
-        In other words, 1 is the parent member of the first member set, so 2 and
-        3 point to 1, etc.
+    -------
+    constraints = {{1,2,3},{4,5},{6,7}}
+    is transformed into the following dictionary:
+    {
+        3:1
+        2:1
+        5:4
+        7:6
+    }
+    In other words, 1 is the parent member of the first member set, so 2 and
+    3 point to 1, etc.
 
     This is useful when setting up matrices for the quadratic programming
     problem when molecular constraint are present.
     """
-
     mapping = {}
     for group in constraints:
         sites = sorted(group)
@@ -254,9 +280,12 @@ def constraint_lookup_dict(constraints):
 
 
 def constraint_aware_uni_map(
-    config_mapping, constraints=None, xyz=None, forces=None,
-):
-    r"""Produces a uniform basic force map compatible with constraints.
+    config_mapping: LinearMap,
+    constraints: Union[None, Constraints] = None,
+    xyz: Union[None, np.ndarray] = None,  # noqa: ARG001
+    forces: Union[None, np.ndarray] = None,  # noqa: ARG001
+) -> LinearMap:
+    r"""Produce a uniform basic force map compatible with constraints.
 
     The given configurational map associates various fine-grained (fg) sites with
     each coarse grained (cg) site. This creates a force-map which:
@@ -273,7 +302,7 @@ def constraint_aware_uni_map(
 
     NOTE: The configurational map is not checked for any kind of correctness.
 
-    Arguments
+    Arguments:
     ---------
     config_mapping (linearmap.LinearMap):
         LinearMap object characterizing the configurational map characterizing
@@ -286,17 +315,19 @@ def constraint_aware_uni_map(
     forces:
         Ignored. Included for compatibility with other mapping methods.
 
-    Returns
+    Returns:
     -------
     LinearMap object describing a force-mapping.
     """
-
+    if constraints is None:
+        constraints = set()
     # get which sites have nonzero contributions to each cg site
     cg_sets = [set(np.nonzero(row)[0]) for row in config_mapping.standard_matrix]
     constraints = reduce_constraint_sets(constraints)
     # add atoms which are related by constraint to those already in cg sites
-    for group in cg_sets:
-        _ = [group.update(x) for x in constraints if group.intersection(x)]
+    for group, x in product(cg_sets, constraints):
+        if group.intersection(x):
+            group.update(x)
     force_map_mat = np.zeros_like(config_mapping.standard_matrix)
     # place a 1 where all original or those pulled in by constraints are
     for cg_index, cg_contents in enumerate(cg_sets):

--- a/src/aggforce/linearmap.py
+++ b/src/aggforce/linearmap.py
@@ -254,10 +254,7 @@ def constraint_lookup_dict(constraints):
 
 
 def constraint_aware_uni_map(
-    config_mapping,
-    constraints=None,
-    xyz=None,
-    forces=None,
+    config_mapping, constraints=None, xyz=None, forces=None,
 ):
     r"""Produces a uniform basic force map compatible with constraints.
 

--- a/tests/test_agg.py
+++ b/tests/test_agg.py
@@ -1,17 +1,23 @@
-"""pytest unit tests for the agg module
+"""Test linear optimized force map generated for a water dimer.
+
+We expect that an optimal force map for a configurational map isolating the oxygens will
+include contributions from the hydrogens. This test confirms that the linear
+force map optimization scheme returns this result.
+
+No bond constraints are present in the reference trajectory.
+
+This result is not a mathematical certainty, but has been empirically true.
 """
-
-
-import os
+from pathlib import Path
 import numpy as np
 from aggforce import linearmap as lm
 from aggforce import agg as ag
 
 
-def test_agg_opt():
-    """Test optimized force aggregation for a flexible water dimer"""
-
-    dimerfile = os.path.join(os.path.dirname(__file__), "data/waterdimer.npz")
+def test_agg_opt() -> None:
+    """Test optimized force aggregation for a flexible water dimer."""
+    location = Path(__file__).parent
+    dimerfile = str(location / "data/waterdimer.npz")
     dimerdata = np.load(dimerfile)
     forces = dimerdata["Fs"]
 
@@ -29,4 +35,4 @@ def test_agg_opt():
     # aggregation mapping: we expect that contributions from each water are added up
     # to cancel the intramolecular bond forces
     agg_mapping = np.array([[1, 1, 1, 0, 0, 0], [0, 0, 0, 1, 1, 1]], dtype=float)
-    assert np.allclose(optim_results["map"]._standard_matrix, agg_mapping, atol=5e-3)
+    assert np.allclose(optim_results["map"].standard_matrix, agg_mapping, atol=5e-3)


### PR DESCRIPTION
Made compatible with ruff, mypy, and black.

This required edits throughout every file. It is possible that output has changed, but this should be minimal and was avoided wherever possible. Tests still run fine, and were confirmed to be fine before changing the types in those files. 

The corresponding type hints are unstable and may change via future PRs.